### PR TITLE
Add react router dom

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -1429,11 +1429,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
-    "@popperjs/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg=="
-    },
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
@@ -6452,6 +6447,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6460,6 +6468,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -8362,6 +8378,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+    },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -10635,7 +10660,6 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^4.1.0",
         "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
@@ -10863,24 +10887,50 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-overlays": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
-      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "@popperjs/core": "^2.0.0",
-        "@restart/hooks": "^0.3.12",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.1.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.0.0",
-        "warning": "^4.0.3"
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-scripts": {
@@ -11275,6 +11325,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12774,6 +12829,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12922,8 +12987,7 @@
       "requires": {
         "@babel/runtime": "^7.6.3",
         "@types/react": "^16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
+        "invariant": "^2.2.4"
       }
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -13175,6 +13239,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -13,6 +13,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3"
   },
   "scripts": {

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,14 +1,22 @@
 import React from 'react'
-
-import Navs from './Nav/Nav'
+import { Route, Switch } from 'react-router-dom'
 
 import './styles/variables.css'
 import './App.css'
+import { Home } from './pages/home'
+import { Forum } from './pages/forum'
+import { Explore } from './pages/explore'
 
-export const App = () => {
+function App() {
   return (
     <div className="App">
-      <Navs />
+      <Switch>
+        <Route exact path="/explore" component={Explore} />
+        <Route exact path="/forum" component={Forum} />
+        <Route path="/" component={Home} />
+      </Switch>
     </div>
   )
 }
+
+export default App

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,25 +1,14 @@
 import React from 'react'
 
-import Navs from './Nav/Nav';
-import './App.css'
-
-function App() {
-  return (<div className="App">
-    <Navs/>
-  </div>)
-
-import { Footer } from './components/Footer'
+import Navs from './Nav/Nav'
 
 import './styles/variables.css'
 import './App.css'
 
-function App() {
+export const App = () => {
   return (
     <div className="App">
-      <Footer />
+      <Navs />
     </div>
   )
-
 }
-
-export default App

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 
-import './styles/variables.css'
-import './App.css'
 import { Home } from './pages/home'
 import { Forum } from './pages/forum'
 import { Explore } from './pages/explore'
+
+import './styles/variables.css'
+import './App.css'
 
 function App() {
   return (

--- a/front-end/src/index.jsx
+++ b/front-end/src/index.jsx
@@ -1,11 +1,16 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import "./index.css";
-import App from "./App";
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
+
+import App from './App'
+
+import './index.css'
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
-  document.getElementById("root")
-);
+  document.getElementById('root')
+)

--- a/front-end/src/layouts/DefaultLayout/DefaultLayout.module.css
+++ b/front-end/src/layouts/DefaultLayout/DefaultLayout.module.css
@@ -1,0 +1,4 @@
+.container {
+    box-sizing: border-box;
+    width: 100%;
+}

--- a/front-end/src/layouts/DefaultLayout/index.jsx
+++ b/front-end/src/layouts/DefaultLayout/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { Footer } from '../../components/Footer'
 
 import styles from './DefaultLayout.module.css'

--- a/front-end/src/layouts/DefaultLayout/index.jsx
+++ b/front-end/src/layouts/DefaultLayout/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Footer } from '../../components/Footer'
+
+import styles from './DefaultLayout.module.css'
+
+export const DefaultLayout = ({ children }) => {
+  return (
+    <div className={styles.container}>
+      <h1>Header</h1>
+      {children}
+      <Footer />
+    </div>
+  )
+}

--- a/front-end/src/pages/explore/index.jsx
+++ b/front-end/src/pages/explore/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import { DefaultLayout } from '../../layouts/DefaultLayout'
+
+export const Explore = () => {
+  return (
+    <DefaultLayout>
+      <p>This will be the explore page</p>
+    </DefaultLayout>
+  )
+}

--- a/front-end/src/pages/forum/index.jsx
+++ b/front-end/src/pages/forum/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import { DefaultLayout } from '../../layouts/DefaultLayout'
+
+export const Forum = () => {
+  return (
+    <DefaultLayout>
+      <p>This will be the forum page</p>
+    </DefaultLayout>
+  )
+}

--- a/front-end/src/pages/home/index.jsx
+++ b/front-end/src/pages/home/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import { DefaultLayout } from '../../layouts/DefaultLayout'
+
+export const Home = () => {
+  return (
+    <DefaultLayout>
+      <p>This will be the home page</p>
+    </DefaultLayout>
+  )
+}


### PR DESCRIPTION
In this PR I added react router dom together with some dummy pages.

Currently, the following routes exist: `/explore`, `/forum`, and `/`.

With this setup, a navbar can be easily added with `<Link>` components from `react-router-dom`.

@KaranSinghBisht What do you think :) ?